### PR TITLE
Support connections to DuckDB for `data-diff --dbt`

### DIFF
--- a/sqeleton/databases/duckdb.py
+++ b/sqeleton/databases/duckdb.py
@@ -166,3 +166,14 @@ class DuckDB(Database):
             return ddb.connect(self._args["filepath"])
         except ddb.OperationalError as e:
             raise ConnectError(*e.args) from e
+
+    def _normalize_table_path(self, path: DbPath) -> DbPath:
+        if len(path) == 1:
+            return self.default_schema, path[0]
+        elif len(path) == 2:
+            return path
+        elif len(path) > 2:
+            # Use only the last two values from the path
+            return path[-2:]
+
+        raise ValueError(f"{self.name}: Bad table path for {self}: '{'.'.join(path)}'. Expected form: schema.table")


### PR DESCRIPTION
I was trying to run the following command when using a [custom fork](https://github.com/dbeatty10/data-diff/pull/1) that added support for duckdb connections:
```
data-diff --dbt
```

But I got the following error:
```
ERROR - DuckDB: Bad table path for <data_diff.databases.duckdb.DuckDB object at 0x10b67f5e0>: 'main.dev.simple_model'. Expected form: schema.table
```

Since I wasn't super interested in discovering why this was happening or how best to solve it, this PR represents my quickest solution to the problem.

Here's the full stack trace:
```
Traceback (most recent call last):
  File "/Users/dbeatty/projects/data-diff/env/bin/data-diff", line 8, in <module>
    sys.exit(main())
  File "/Users/dbeatty/projects/data-diff/env/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dbeatty/projects/data-diff/env/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/dbeatty/projects/data-diff/env/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dbeatty/projects/data-diff/env/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/dbeatty/projects/data-diff/data_diff/__main__.py", line 267, in main
    dbt_diff(
  File "/Users/dbeatty/projects/data-diff/data_diff/dbt.py", line 76, in dbt_diff
    _local_diff(diff_vars)
  File "/Users/dbeatty/projects/data-diff/data_diff/dbt.py", line 124, in _local_diff
    table1_columns = list(table1.get_schema())
  File "/Users/dbeatty/projects/data-diff/data_diff/table_segment.py", line 85, in get_schema
    return self.database.query_table_schema(self.table_path)
  File "/Users/dbeatty/projects/data-diff/env/lib/python3.9/site-packages/sqeleton/databases/base.py", line 389, in query_table_schema
    rows = self.query(self.select_table_schema(path), list)
  File "/Users/dbeatty/projects/data-diff/env/lib/python3.9/site-packages/sqeleton/databases/base.py", line 380, in select_table_schema
    schema, name = self._normalize_table_path(path)
  File "/Users/dbeatty/projects/data-diff/env/lib/python3.9/site-packages/sqeleton/databases/base.py", line 488, in _normalize_table_path
    raise ValueError(f"{self.name}: Bad table path for {self}: '{'.'.join(path)}'. Expected form: schema.table")
ValueError: DuckDB: Bad table path for <data_diff.databases.duckdb.DuckDB object at 0x10b67f5e0>: 'main.dev.simple_model'. Expected form: schema.table
```