### PR TITLE
Use the same `select_table_schema` and `_normalize_table_path` as Redshift

### DIFF
--- a/sqeleton/databases/duckdb.py
+++ b/sqeleton/databases/duckdb.py
@@ -167,13 +167,26 @@ class DuckDB(Database):
         except ddb.OperationalError as e:
             raise ConnectError(*e.args) from e
 
+    def select_table_schema(self, path: DbPath) -> str:
+        database, schema, table = self._normalize_table_path(path)
+
+        info_schema_path = ["information_schema", "columns"]
+        if database:
+            info_schema_path.insert(0, database)
+
+        return (
+            f"SELECT column_name, data_type, datetime_precision, numeric_precision, numeric_scale FROM {'.'.join(info_schema_path)} "
+            f"WHERE table_name = '{table.lower()}' AND table_schema = '{schema.lower()}'"
+        )
+
     def _normalize_table_path(self, path: DbPath) -> DbPath:
         if len(path) == 1:
-            return self.default_schema, path[0]
+            return None, self.default_schema, path[0]
         elif len(path) == 2:
+            return None, path[0], path[1]
+        elif len(path) == 3:
             return path
-        elif len(path) > 2:
-            # Use only the last two values from the path
-            return path[-2:]
 
-        raise ValueError(f"{self.name}: Bad table path for {self}: '{'.'.join(path)}'. Expected form: schema.table")
+        raise ValueError(
+            f"{self.name}: Bad table path for {self}: '{'.'.join(path)}'. Expected format: table, schema.table, or database.schema.table"
+        )


### PR DESCRIPTION
### History
https://github.com/datafold/sqeleton/pull/22 was an initial attempt at unblocking `data-diff --dbt` for DuckDB. This is a second attempt.

### Enabling 3-part fully-qualified names (FQN)
This 2nd attempt enables all of the following:
- 1-part paths
- 2-part paths
- 3-part paths

The latter is especially important for the following reasons:
1. DuckDB 0.7.0 adds support for [attaching multiple databases](https://duckdb.org/docs/sql/statements/attach#name-qualification)
2. It appears that prior to DuckDB 0.7.0, supplying a database/catalog in a 3-part path is allowed and handled gracefully

### Implementation details
Both DuckDB and Redshift have lots of similarities with PostgreSQL. So for this implementation, I just copied-pasted two methods from redshift to duckdb:
1. `select_table_schema`
2. `_normalize_table_path`